### PR TITLE
Always use cloudfoundry auth provider.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -16,7 +16,7 @@ import (
 func rootHandler(res http.ResponseWriter, req *http.Request) {
 	s, _ := gothic.Store.Get(req, "uaa-proxy-session")
 	if s.Values["logged"] != true {
-		http.Redirect(res, req, "/auth/cloudfoundry", http.StatusTemporaryRedirect)
+		http.Redirect(res, req, "/auth", http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
Note: we could also modify `GetProviderName` to get the provider name
from path parameters instead of query parameters. But given that this is
meant to be used with cloudfoundry, hard-coding seems like the most
straightforward option.

@dlapiduz: I haven't had time to verify manually--want to pair up later and try it out?
