### PR TITLE
Use Header.Set instead of Header.Add

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -62,7 +62,7 @@ func newProxy(remote_user string) http.Handler {
 			}
 			req.URL = url
 			req.Host = url.Host
-			req.Header.Add("X-Auth-User", remote_user)
+			req.Header.Set("X-Auth-User", remote_user)
 
 			fmt.Println(req.Header)
 		},

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -46,7 +46,7 @@ func TestProxy(t *testing.T) {
 		// Be sure there's only one X-Auth-User header and
 		// it's what we expect
 		assert.Equal(t, len(req.Header["X-Auth-User"]), 1)
-		assert.Equal(t, req.Header["X-Auth-User"][0], "fred@queen.com")
+		assert.Equal(t, req.Header.Get("X-Auth-User"), "fred@queen.com")
 
 		body, err := ioutil.ReadAll(res.Body)
 		assert.Nil(t, err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -34,10 +34,17 @@ func TestProxy(t *testing.T) {
 		sess.Values["user_email"] = "fred@queen.com"
 		sess.Values["logged"] = true
 
+		req.Header.Set("X-Auth-User", "auth-user-from-client")
+
 		res := httptest.NewRecorder()
 		handler.ServeHTTP(res, req)
 
 		assert.Equal(t, res.Code, http.StatusOK)
+
+		// Be sure there's only one X-Auth-User header and
+		// it's what we expect
+		assert.Equal(t, len(req.Header["X-Auth-User"]), 1)
+		assert.Equal(t, req.Header["X-Auth-User"][0], "fred@queen.com")
 
 		body, err := ioutil.ReadAll(res.Body)
 		assert.Nil(t, err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -34,6 +34,8 @@ func TestProxy(t *testing.T) {
 		sess.Values["user_email"] = "fred@queen.com"
 		sess.Values["logged"] = true
 
+		// Set some invalid value so we can be sure that it's
+		// being overwritten internally.
 		req.Header.Set("X-Auth-User", "auth-user-from-client")
 
 		res := httptest.NewRecorder()


### PR DESCRIPTION
`Header.Add` will append a new value to the header if the key already exists.  This seems like a security/trust problem.  Apps protected by `cf-uaa-guard-service` can only identify users by the `X-Auth-User` header, so they need to be able to trust that the value in that header came exclusively from the service.  `Header.Set` will replace any header values with the key, which should ensure that is the case.
